### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger_build.yml
+++ b/.github/workflows/trigger_build.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   trigger-bnp:
     name: Trigger build & publish
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1


### PR DESCRIPTION
Potential fix for [https://github.com/outloudvi/mw2fcitx/security/code-scanning/1](https://github.com/outloudvi/mw2fcitx/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or job definition to explicitly set the least privilege required. Since the job only triggers another workflow using the GitHub API (via `actions/github-script`), it only needs `contents: read` permission to access repository contents, and possibly `actions: write` to trigger workflows. The best practice is to add the `permissions` block at the job level (under `trigger-bnp`), specifying only the permissions required. This change should be made in `.github/workflows/trigger_build.yml`, directly under the job definition (after `name:` and before `runs-on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
